### PR TITLE
Refactor: Update PrimaryButton icon parameter

### DIFF
--- a/chatia-ui-components/src/commonMain/kotlin/com/chatia/ui/components/buttons/PrimaryButton.kt
+++ b/chatia-ui-components/src/commonMain/kotlin/com/chatia/ui/components/buttons/PrimaryButton.kt
@@ -54,7 +54,7 @@ fun PrimaryButton(
     textColor: Color = Color.White,
     textFontWeight: FontWeight,
     textFontSize: TextUnit = 16.sp,
-    drawableResource: DrawableResource? = null,
+    icon: (@Composable (() -> Unit))? = null,
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     elevation: ButtonElevation? = null
 ) {
@@ -67,13 +67,10 @@ fun PrimaryButton(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(2.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            drawableResource?.let {
-                Icon(
-                    painter = painterResource(it),
-                    contentDescription = null,
-                )
+            icon?.let {
+                it()
             }
             PrimaryText(
                 text = text,


### PR DESCRIPTION
The `PrimaryButton` composable has been updated to accept a generic `(@Composable () -> Unit)?` for its `icon` parameter, replacing the previous `DrawableResource?` type.

This change provides more flexibility in how icons are rendered within the button, allowing any composable to be used as an icon.

The horizontal arrangement spacing within the button's internal `Row` has also been increased from `2.dp` to `6.dp`.